### PR TITLE
Use extras in tox instead of self-referencing the package in deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ envlist =
 
 [testenv]
 passenv = *
-deps =
-    .[test]
+extras =
+    test
 commands =
     pytest {posargs}
 


### PR DESCRIPTION
This is the more idiomatic way.

Also, it allows Fedora packaging to actually install the deps.